### PR TITLE
Change CAN name rules

### DIFF
--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -335,9 +335,10 @@ namespace eosiosystem {
 
          bool has_below_6_chars = (newact.value & 0x3FFFFFFF0ull) == 0;
 
-         if( has_dot  && has_below_6_chars) { // or is less than 12 characters
+         if( has_dot) { // or is less than 12 characters
             auto suffix = newact.suffix();
-            if( suffix == newact ) {
+            if( suffix == newact && has_below_6_chars) {
+               check( false, "disable at this time" );
                name_bid_table bids(get_self(), get_self().value);
                auto current = bids.find( newact.value );
                check( current != bids.end(), "no active bid for name" );

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -332,17 +332,19 @@ namespace eosiosystem {
            has_dot |= !(tmp & 0x1f);
            tmp >>= 5;
          }
-         if( has_dot ) { // or is less than 12 characters
+
+         bool has_below_6_chars = (newact.value & 0x3FFFFFFF0ull) == 0;
+
+         if( has_dot  && has_below_6_chars) { // or is less than 12 characters
             auto suffix = newact.suffix();
             if( suffix == newact ) {
-               check( false, "disable name auction");
                name_bid_table bids(get_self(), get_self().value);
                auto current = bids.find( newact.value );
                check( current != bids.end(), "no active bid for name" );
                check( current->high_bidder == creator, "only highest bidder can claim" );
                check( current->high_bid < 0, "auction for name is not closed yet" );
                bids.erase( current );
-            } else {
+            } else if (suffix != newact){
                check( creator == suffix, "only suffix may create this account" );
             }
          }

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -333,7 +333,7 @@ namespace eosiosystem {
            tmp >>= 5;
          }
 
-         bool has_below_6_chars = (newact.value & 0x3FFFFFFF0ull) == 0;
+         bool has_below_6_chars = (newact.value & 0x7FFFFFFFF0ull) == 0;
 
          if( has_dot) { // or is less than 12 characters
             auto suffix = newact.suffix();
@@ -345,8 +345,10 @@ namespace eosiosystem {
                check( current->high_bidder == creator, "only highest bidder can claim" );
                check( current->high_bid < 0, "auction for name is not closed yet" );
                bids.erase( current );
-            } else if (suffix != newact){
+            } else if (suffix != newact && has_below_6_chars){
                check( creator == suffix, "only suffix may create this account" );
+            } else if (suffix != newact && !has_below_6_chars){
+               check( false, "only premium name can create name with dot" );
             }
          }
       }

--- a/contracts/eosio.system/src/name_bidding.cpp
+++ b/contracts/eosio.system/src/name_bidding.cpp
@@ -14,7 +14,7 @@ namespace eosiosystem {
 
       check( (bool)newname, "the empty name is not a valid account name to bid on" );
       check( (newname.value & 0xFull) == 0, "13 character names are not valid account names to bid on" );
-      check( (newname.value & 0x3FFFFFFF0ull) == 0, "accounts with 6 character names and no dots can be created without bidding required" );      check( !is_account( newname ), "account already exists" );
+      check( (newname.value & 0x7FFFFFFFF0ull) == 0, "accounts with 6 character names and no dots can be created without bidding required" );      check( !is_account( newname ), "account already exists" );
       check( bid.symbol == core_symbol(), "asset must be system token" );
       check( bid.amount > 0, "insufficient bid" );
       token::transfer_action transfer_act{ token_account, { {bidder, active_permission} } };

--- a/contracts/eosio.system/src/name_bidding.cpp
+++ b/contracts/eosio.system/src/name_bidding.cpp
@@ -10,6 +10,8 @@ namespace eosiosystem {
 
    void system_contract::bidname( const name& bidder, const name& newname, const asset& bid ) {
       require_auth( bidder );
+      check( false, "disable at this time" );
+      
       check( newname.suffix() == newname, "you can only bid on top-level suffix" );
 
       check( (bool)newname, "the empty name is not a valid account name to bid on" );

--- a/contracts/eosio.system/src/name_bidding.cpp
+++ b/contracts/eosio.system/src/name_bidding.cpp
@@ -14,8 +14,7 @@ namespace eosiosystem {
 
       check( (bool)newname, "the empty name is not a valid account name to bid on" );
       check( (newname.value & 0xFull) == 0, "13 character names are not valid account names to bid on" );
-      check( (newname.value & 0x1F0ull) == 0, "accounts with 12 character names and no dots can be created without bidding required" );
-      check( !is_account( newname ), "account already exists" );
+      check( (newname.value & 0x3FFFFFFF0ull) == 0, "accounts with 6 character names and no dots can be created without bidding required" );      check( !is_account( newname ), "account already exists" );
       check( bid.symbol == core_symbol(), "asset must be system token" );
       check( bid.amount > 0, "insufficient bid" );
       token::transfer_action transfer_act{ token_account, { {bidder, active_permission} } };


### PR DESCRIPTION

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

* A account length can be between 6 and 12 (both inclusive).
* Available characters are a to z and 1 to 5.
* Users whose account length is between 6 and 12 can't create other accounts ending with dot and their username.
* The premium name market is closed at the time of launching the mainnet.
* The premium name market to be opened later will allow to bid username less than 6 and to use it to create other accounts ending with dot and the username. 

## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
