### PR TITLE
Release can.v1.2.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.associations": {
+    "chrono": "cpp"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # can.contracts
 
-## Version : 1.1.0
+## Version : 1.2.0
 
 The design of the CAN blockchain calls for a number of smart contracts that are run at a privileged permission level in order to support functions such as block producer registration and voting, token staking for CPU and network bandwidth, RAM purchasing, multi-sig, etc.  These smart contracts are referred to as the bios, system, msig, wrap (formerly known as sudo) and token contracts.
 
@@ -16,7 +16,7 @@ The following unprivileged contract(s) are also part of the system.
 
 Dependencies:
 * [eosio.cdt v1.7.x](https://github.com/EOSIO/eosio.cdt/releases/tag/v1.7.0)
-* [can v2.0.x](https://github.com/canfoundation/CAN/releases/tag/can-v1.0.0) (optional dependency only needed to build unit tests)
+* [can v2.0.x](https://github.com/canfoundation/CAN/releases/tag/can-v1.2.0) (optional dependency only needed to build unit tests)
 
 To build the contracts follow the instructions in [`Build and deploy` section](./docs/02_build-and-deploy.md).
 

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -335,9 +335,10 @@ namespace eosiosystem {
 
          bool has_below_6_chars = (newact.value & 0x3FFFFFFF0ull) == 0;
 
-         if( has_dot  && has_below_6_chars) { // or is less than 12 characters
+         if( has_dot) { // or is less than 12 characters
             auto suffix = newact.suffix();
-            if( suffix == newact ) {
+            if( suffix == newact && has_below_6_chars) {
+               check( false, "disable at this time" );
                name_bid_table bids(get_self(), get_self().value);
                auto current = bids.find( newact.value );
                check( current != bids.end(), "no active bid for name" );

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -333,11 +333,12 @@ namespace eosiosystem {
            tmp >>= 5;
          }
 
-         bool has_below_6_chars = (newact.value & 0x7FFFFFFFF0ull) == 0;
+         bool has_newaccount_below_6_chars = (newact.value & 0x7FFFFFFFF0ull) == 0;
+         bool has_creator_below_6_chars = (creator.value & 0x7FFFFFFFF0ull) == 0;
 
          if( has_dot) { // or is less than 12 characters
             auto suffix = newact.suffix();
-            if( suffix == newact && has_below_6_chars) {
+            if( suffix == newact && has_newaccount_below_6_chars) {
                check( false, "disable at this time" );
                name_bid_table bids(get_self(), get_self().value);
                auto current = bids.find( newact.value );
@@ -345,11 +346,14 @@ namespace eosiosystem {
                check( current->high_bidder == creator, "only highest bidder can claim" );
                check( current->high_bid < 0, "auction for name is not closed yet" );
                bids.erase( current );
-            } else if (suffix != newact && has_below_6_chars){
-               check( creator == suffix, "only suffix may create this account" );
-            } else if (suffix != newact && !has_below_6_chars){
-               check( false, "only premium name can create name with dot" );
-            }
+            } else if (suffix != newact) {
+               check( creator == suffix, "only suffix may create this account");
+               check( has_creator_below_6_chars, "only premium name can create name with dot" );
+
+               // creator length < 6 && newaccount length < 6 && suffix != newact && creator == suffix
+               // is considering this case should be accepted or not
+               check(!has_newaccount_below_6_chars, "can not create new sub account shoter than 6 characters" );
+            }  
          }
       }
 

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -332,17 +332,19 @@ namespace eosiosystem {
            has_dot |= !(tmp & 0x1f);
            tmp >>= 5;
          }
-         if( has_dot ) { // or is less than 12 characters
+
+         bool has_below_6_chars = (newact.value & 0x3FFFFFFF0ull) == 0;
+
+         if( has_dot  && has_below_6_chars) { // or is less than 12 characters
             auto suffix = newact.suffix();
             if( suffix == newact ) {
-               check( false, "disable name auction");
                name_bid_table bids(get_self(), get_self().value);
                auto current = bids.find( newact.value );
                check( current != bids.end(), "no active bid for name" );
                check( current->high_bidder == creator, "only highest bidder can claim" );
                check( current->high_bid < 0, "auction for name is not closed yet" );
                bids.erase( current );
-            } else {
+            } else if (suffix != newact){
                check( creator == suffix, "only suffix may create this account" );
             }
          }

--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -333,7 +333,7 @@ namespace eosiosystem {
            tmp >>= 5;
          }
 
-         bool has_below_6_chars = (newact.value & 0x3FFFFFFF0ull) == 0;
+         bool has_below_6_chars = (newact.value & 0x7FFFFFFFF0ull) == 0;
 
          if( has_dot) { // or is less than 12 characters
             auto suffix = newact.suffix();
@@ -345,8 +345,10 @@ namespace eosiosystem {
                check( current->high_bidder == creator, "only highest bidder can claim" );
                check( current->high_bid < 0, "auction for name is not closed yet" );
                bids.erase( current );
-            } else if (suffix != newact){
+            } else if (suffix != newact && has_below_6_chars){
                check( creator == suffix, "only suffix may create this account" );
+            } else if (suffix != newact && !has_below_6_chars){
+               check( false, "only premium name can create name with dot" );
             }
          }
       }

--- a/contracts/eosio.system/src/name_bidding.cpp
+++ b/contracts/eosio.system/src/name_bidding.cpp
@@ -14,7 +14,7 @@ namespace eosiosystem {
 
       check( (bool)newname, "the empty name is not a valid account name to bid on" );
       check( (newname.value & 0xFull) == 0, "13 character names are not valid account names to bid on" );
-      check( (newname.value & 0x3FFFFFFF0ull) == 0, "accounts with 6 character names and no dots can be created without bidding required" );      check( !is_account( newname ), "account already exists" );
+      check( (newname.value & 0x7FFFFFFFF0ull) == 0, "accounts with 6 character names and no dots can be created without bidding required" );      check( !is_account( newname ), "account already exists" );
       check( bid.symbol == core_symbol(), "asset must be system token" );
       check( bid.amount > 0, "insufficient bid" );
       token::transfer_action transfer_act{ token_account, { {bidder, active_permission} } };

--- a/contracts/eosio.system/src/name_bidding.cpp
+++ b/contracts/eosio.system/src/name_bidding.cpp
@@ -10,6 +10,8 @@ namespace eosiosystem {
 
    void system_contract::bidname( const name& bidder, const name& newname, const asset& bid ) {
       require_auth( bidder );
+      check( false, "disable at this time" );
+      
       check( newname.suffix() == newname, "you can only bid on top-level suffix" );
 
       check( (bool)newname, "the empty name is not a valid account name to bid on" );

--- a/contracts/eosio.system/src/name_bidding.cpp
+++ b/contracts/eosio.system/src/name_bidding.cpp
@@ -14,8 +14,7 @@ namespace eosiosystem {
 
       check( (bool)newname, "the empty name is not a valid account name to bid on" );
       check( (newname.value & 0xFull) == 0, "13 character names are not valid account names to bid on" );
-      check( (newname.value & 0x1F0ull) == 0, "accounts with 12 character names and no dots can be created without bidding required" );
-      check( !is_account( newname ), "account already exists" );
+      check( (newname.value & 0x3FFFFFFF0ull) == 0, "accounts with 6 character names and no dots can be created without bidding required" );      check( !is_account( newname ), "account already exists" );
       check( bid.symbol == core_symbol(), "asset must be system token" );
       check( bid.amount > 0, "insufficient bid" );
       token::transfer_action transfer_act{ token_account, { {bidder, active_permission} } };


### PR DESCRIPTION
Feature:

- A account length can be between 6 and 12 (both inclusive).
- Available characters are a to z and 1 to 5.
- Users whose account length is between 6 and 12 can't create other accounts ending with dot and their username.
- The premium name market is closed at the time of launching the mainnet.
- The premium name market to be opened later will allow to bid username less than 6 and to use it to create other accounts ending with dot and the username.